### PR TITLE
fix: remove `v` prefix from version

### DIFF
--- a/specifiers/specifier_mapper.test.ts
+++ b/specifiers/specifier_mapper.test.ts
@@ -34,4 +34,13 @@ Deno.test("maps specifiers", async () => {
       subpath: "",
     },
   );
+
+  assertEquals(
+    await mapper.map("https://deno.land/x/ts_morph@v21.0.0/mod.ts"),
+    {
+      bareSpecifier: `@david/ts-morph`,
+      base: `jsr:@david/ts-morph@21.0.0`,
+      subpath: "",
+    },
+  );
 });

--- a/specifiers/specifier_mapper.ts
+++ b/specifiers/specifier_mapper.ts
@@ -88,7 +88,7 @@ class DenoStdMapper {
   }
 }
 
-const denoLandRe = /^https:\/\/deno\.land\/x\/([^@]+)@([^/]+)\/(.+)$/;
+const denoLandRe = /^https:\/\/deno\.land\/x\/([^@]+)@v?([^/]+)\/(.+)$/;
 
 class DenoLandMapper {
   #slashXToJsrPkgMapper: SlashXToJsrPkgMapper;


### PR DESCRIPTION
## Summary

This PR provides a fix that remove `v` prefix from version.

## Motivation

Some modules provide its with `v` prefix:

- `https://deno.land/x/cliffy@v1.0.0-rc.4`
- `https://deno.land/x/hono@v4.3.11`

etc.

On jsr.io, they does not have `v` prefix.

- https://jsr.io/@cliffy/command/versions
- https://jsr.io/@hono/hono/versions

Currently, `x-to-jsr` dont strip `v`.

This behavior can be confusing for some users.

So, I fixed regexp to ignore `v` prefix.